### PR TITLE
Added an alias to depricated clone

### DIFF
--- a/lib/winston-couchdb.js
+++ b/lib/winston-couchdb.js
@@ -14,6 +14,20 @@ var winston = require('winston'),
     cycle = require('cycle'),
     Stream = require('stream').Stream;
 
+/**
+ * Compatiability function for Winston3. Clone funtion doesn't exist there so making one here which does
+ * what Winston3 does.
+ * @param {*} source 
+ */
+const clone = (source) => {
+  return Object.assign({}, source)
+}
+/**
+ * Add our compatibility clone function if not present in winston
+ */
+if(!("clone" in common)){
+  common.clone =  clone;
+}
 //
 // ### function Couchdb (options)
 // #### @options {Object} Options for this instance.


### PR DESCRIPTION
Winston3 doesn't have the clone function in common anymore. It simply uses the Object.assign to create a shallow clone. So I made an alias for clone that gets attached to common if it's not present.